### PR TITLE
Add a timer facility to wasi-clocks.

### DIFF
--- a/wasi-clocks.abi.md
+++ b/wasi-clocks.abi.md
@@ -51,6 +51,20 @@ Size: 16, Alignment: 8
 
 ----
 
+#### <a href="#monotonic_clock_new_timer" name="monotonic_clock_new_timer"></a> `monotonic-clock::new-timer` 
+
+  This creates a new `monotonic-timer` with the given starting time. It will
+  count down from this time until it reaches zero.
+##### Params
+
+- <a href="#monotonic_clock_new_timer.self" name="monotonic_clock_new_timer.self"></a> `self`: handle<monotonic-clock>
+- <a href="#monotonic_clock_new_timer.initial" name="monotonic_clock_new_timer.initial"></a> `initial`: [`instant`](#instant)
+##### Results
+
+- <a href="#monotonic_clock_new_timer." name="monotonic_clock_new_timer."></a> ``: handle<monotonic-timer>
+
+----
+
 #### <a href="#wall_clock_now" name="wall_clock_now"></a> `wall-clock::now` 
 
   Read the current value of the clock.
@@ -86,4 +100,16 @@ Size: 16, Alignment: 8
 ##### Results
 
 - <a href="#wall_clock_resolution." name="wall_clock_resolution."></a> ``: [`datetime`](#datetime)
+
+----
+
+#### <a href="#monotonic_timer_current" name="monotonic_timer_current"></a> `monotonic-timer::current` 
+
+  Returns the amount of time left before this timer reaches zero.
+##### Params
+
+- <a href="#monotonic_timer_current.self" name="monotonic_timer_current.self"></a> `self`: handle<monotonic-timer>
+##### Results
+
+- <a href="#monotonic_timer_current." name="monotonic_timer_current."></a> ``: [`instant`](#instant)
 

--- a/wasi-clocks.wit.md
+++ b/wasi-clocks.wit.md
@@ -45,6 +45,13 @@ now: function() -> instant
 resolution: function() -> instant
 ```
 
+## `new-timer`
+```wit
+/// This creates a new `monotonic-timer` with the given starting time. It will
+/// count down from this time until it reaches zero.
+new-timer: function(initial: instant) -> handle monotonic-timer
+```
+
 ```wit
 }
 ```
@@ -85,6 +92,23 @@ now: function() -> datetime
 ///
 /// The nanoseconds field of the output is always less than 1000000000.
 resolution: function() -> datetime
+```
+
+```wit
+}
+```
+
+## `monotonic-timer`
+```wit
+/// This is a timer that counts down from a given starting time down to zero
+/// on a monotonic clock.
+resource monotonic-timer {
+```
+
+## `current`
+```wit
+/// Returns the amount of time left before this timer reaches zero.
+current: function() -> instant
 ```
 
 ```wit


### PR DESCRIPTION
Add a timer facility that allows one to create timers that start at a
given time and count down to zero, on a given clock.

The expectation is that this can be used in combination with polling to
implement more flexible timeouts.