### PR TITLE
Update to the latest wasi-tools.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,4 +13,4 @@ jobs:
     - uses: actions/checkout@v2
     - uses: WebAssembly/wit-abi-up-to-date@v2
       with:
-        wit-abi-tag: wit-abi-0.1.0
+        wit-abi-tag: wit-abi-0.3.0

--- a/wasi-clocks.abi.md
+++ b/wasi-clocks.abi.md
@@ -33,9 +33,9 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#monotonic_clock_now.self" name="monotonic_clock_now.self"></a> `self`: handle<monotonic-clock>
-##### Results
+##### Result
 
-- <a href="#monotonic_clock_now." name="monotonic_clock_now."></a> ``: [`instant`](#instant)
+- [`instant`](#instant)
 
 ----
 
@@ -45,9 +45,9 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#monotonic_clock_resolution.self" name="monotonic_clock_resolution.self"></a> `self`: handle<monotonic-clock>
-##### Results
+##### Result
 
-- <a href="#monotonic_clock_resolution." name="monotonic_clock_resolution."></a> ``: [`instant`](#instant)
+- [`instant`](#instant)
 
 ----
 
@@ -59,9 +59,9 @@ Size: 16, Alignment: 8
 
 - <a href="#monotonic_clock_new_timer.self" name="monotonic_clock_new_timer.self"></a> `self`: handle<monotonic-clock>
 - <a href="#monotonic_clock_new_timer.initial" name="monotonic_clock_new_timer.initial"></a> `initial`: [`instant`](#instant)
-##### Results
+##### Result
 
-- <a href="#monotonic_clock_new_timer." name="monotonic_clock_new_timer."></a> ``: handle<monotonic-timer>
+- handle<monotonic-timer>
 
 ----
 
@@ -83,9 +83,9 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#wall_clock_now.self" name="wall_clock_now.self"></a> `self`: handle<wall-clock>
-##### Results
+##### Result
 
-- <a href="#wall_clock_now." name="wall_clock_now."></a> ``: [`datetime`](#datetime)
+- [`datetime`](#datetime)
 
 ----
 
@@ -97,9 +97,9 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#wall_clock_resolution.self" name="wall_clock_resolution.self"></a> `self`: handle<wall-clock>
-##### Results
+##### Result
 
-- <a href="#wall_clock_resolution." name="wall_clock_resolution."></a> ``: [`datetime`](#datetime)
+- [`datetime`](#datetime)
 
 ----
 
@@ -109,7 +109,7 @@ Size: 16, Alignment: 8
 ##### Params
 
 - <a href="#monotonic_timer_current.self" name="monotonic_timer_current.self"></a> `self`: handle<monotonic-timer>
-##### Results
+##### Result
 
-- <a href="#monotonic_timer_current." name="monotonic_timer_current."></a> ``: [`instant`](#instant)
+- [`instant`](#instant)
 

--- a/wasi-clocks.wit.md
+++ b/wasi-clocks.wit.md
@@ -36,20 +36,20 @@ resource monotonic-clock {
 ///
 /// As this the clock is monotonic, calling this function repeatedly will produce
 /// a sequence of non-decreasing values.
-now: function() -> instant
+now: func() -> instant
 ```
 
 ## `resolution`
 ```wit
 /// Query the resolution of the clock.
-resolution: function() -> instant
+resolution: func() -> instant
 ```
 
 ## `new-timer`
 ```wit
 /// This creates a new `monotonic-timer` with the given starting time. It will
 /// count down from this time until it reaches zero.
-new-timer: function(initial: instant) -> handle monotonic-timer
+new-timer: func(initial: instant) -> handle monotonic-timer
 ```
 
 ```wit
@@ -83,7 +83,7 @@ resource wall-clock {
 ///
 /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
 /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
-now: function() -> datetime
+now: func() -> datetime
 ```
 
 ## `resolution`
@@ -91,7 +91,7 @@ now: function() -> datetime
 /// Query the resolution of the clock.
 ///
 /// The nanoseconds field of the output is always less than 1000000000.
-resolution: function() -> datetime
+resolution: func() -> datetime
 ```
 
 ```wit
@@ -108,7 +108,7 @@ resource monotonic-timer {
 ## `current`
 ```wit
 /// Returns the amount of time left before this timer reaches zero.
-current: function() -> instant
+current: func() -> instant
 ```
 
 ```wit


### PR DESCRIPTION
This includes an update to the latest wit-bindgen, which includes the
rename from `function` to `func`.