### PR TITLE
Add a default clocks API.

### DIFF
--- a/wasi-default-clocks.wit.md
+++ b/wasi-default-clocks.wit.md
@@ -1,0 +1,19 @@
+# WASI Default Clocks API
+
+WASI Default Clocks provides value-exports of clock handles for monotonic
+and a wall-clock time, suitable for general-purpose application needs.
+
+## Imports
+```wit
+use { monotonic-clock, wall-clock } from wasi-clocks
+```
+
+## `default-monotonic-clock`
+```wit
+default-monotonic-clock: monotonic-clock
+```
+
+## `default-wall-clock`
+```wit
+default-wall-clock: wall-clock
+```


### PR DESCRIPTION
In Preview2 commands, we need a way for commands to obtain handles for
wall-clock and monotonic clocks. See also bytecodealliance/wasi-libc#12.

This PR adds a new wit file, wasi-default-clocks.wit.md, which defines
value exports providing these clock handle values.