### PR TITLE
Add a way to get a future for a timer.

### DIFF
--- a/wasi-clocks.abi.md
+++ b/wasi-clocks.abi.md
@@ -113,3 +113,15 @@ Size: 16, Alignment: 8
 
 - [`instant`](#instant)
 
+----
+
+#### <a href="#monotonic_timer_expiration" name="monotonic_timer_expiration"></a> `monotonic-timer::expiration` 
+
+  Returns a future that completes when the timer reaches zero.
+##### Params
+
+- <a href="#monotonic_timer_expiration.self" name="monotonic_timer_expiration.self"></a> `self`: handle<monotonic-timer>
+##### Result
+
+- future<`unit`>
+

--- a/wasi-clocks.wit.md
+++ b/wasi-clocks.wit.md
@@ -111,6 +111,12 @@ resource monotonic-timer {
 current: func() -> instant
 ```
 
+## `expiration`
+```wit
+/// Returns a future that completes when the timer reaches zero.
+expiration: func() -> future<unit>
+```
+
 ```wit
 }
 ```


### PR DESCRIPTION
cabi listen needs a future or stream, so add a function that produces
a future from a timer, allowing it to be waited for by cabi wait.

An alternative would be to have the `new` function return a future
directly, rather than a resource, however that wouldn't support reading
the current time from a timer.

Fixes #18.