### PR TITLE
Add comments documenting the default-clock functions.

### DIFF
--- a/wasi-default-clocks.wit.md
+++ b/wasi-default-clocks.wit.md
@@ -10,10 +10,21 @@ use { monotonic-clock, wall-clock } from wasi-clocks
 
 ## `default-monotonic-clock`
 ```wit
+/// Return a default monotonic clock, suitable for general-purpose application
+/// needs.
+///
+/// This allocates a new handle, so applications with frequent need of a clock
+/// handle should call this function once and reuse the handle instead of
+/// calling this function each time.
 default-monotonic-clock: monotonic-clock
 ```
 
 ## `default-wall-clock`
+/// Return a default wall clock, suitable for general-purpose application
+/// needs.
+///
+/// This allocates a new handle, so applications with frequent need of a clock
+/// handle should call this function once and reuse the handle instead of
 ```wit
 default-wall-clock: wall-clock
 ```


### PR DESCRIPTION
These functions allocate a new handle on each call, which may have some overhead, so document that applications that need frequent clock access should call them once instead of once each time they need a clock.
