### PR TITLE
Fix the interface names for the instance interfaces.

### DIFF
--- a/wit/instance-monotonic-clock.wit
+++ b/wit/instance-monotonic-clock.wit
@@ -1,6 +1,6 @@
 /// This interfaces proves a clock handles for monotonic clock, suitable for
 /// general-purpose application needs.
-default interface instance-clocks {
+default interface instance-monotonic-clock {
     use pkg.monotonic-clock.{monotonic-clock}
 
     /// Return a handle to a monotonic clock, suitable for general-purpose

--- a/wit/instance-wall-clock.wit
+++ b/wit/instance-wall-clock.wit
@@ -1,6 +1,6 @@
 /// This interfaces proves a clock handles for wall clock, suitable for
 /// general-purpose application needs.
-default interface instance-clocks {
+default interface instance-wall-clock {
     use pkg.wall-clock.{wall-clock}
 
     /// Return a handle to a wall clock, suitable for general-purpose


### PR DESCRIPTION
Instance monotonic and wall clocks now have their own interfaces, so give them their own interface names.