### PR TITLE
Document per-item versions using `@since` gates

### DIFF
--- a/imports.md
+++ b/imports.md
@@ -98,7 +98,7 @@ corresponding to a clock tick.</p>
 </ul>
 <h4><a name="subscribe_instant"></a><code>subscribe-instant: func</code></h4>
 <p>Create a <a href="#pollable"><code>pollable</code></a> which will resolve once the specified instant
-has occurred.</p>
+has occured.</p>
 <h5>Params</h5>
 <ul>
 <li><a name="subscribe_instant.when"></a><code>when</code>: <a href="#instant"><a href="#instant"><code>instant</code></a></a></li>

--- a/wit/monotonic-clock.wit
+++ b/wit/monotonic-clock.wit
@@ -7,35 +7,42 @@ package wasi:clocks@0.2.0;
 ///
 /// A monotonic clock is a clock which has an unspecified initial value, and
 /// successive reads of the clock will produce non-decreasing values.
+@since(version = 0.2.0)
 interface monotonic-clock {
     use wasi:io/poll@0.2.0.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from
     /// the same monotonic-clock.
+    @since(version = 0.2.0)
     type instant = u64;
 
     /// A duration of time, in nanoseconds.
+    @since(version = 0.2.0)
     type duration = u64;
 
     /// Read the current value of the clock.
     ///
     /// The clock is monotonic, therefore calling this function repeatedly will
     /// produce a sequence of non-decreasing values.
+    @since(version = 0.2.0)
     now: func() -> instant;
 
     /// Query the resolution of the clock. Returns the duration of time
     /// corresponding to a clock tick.
+    @since(version = 0.2.0)
     resolution: func() -> duration;
 
     /// Create a `pollable` which will resolve once the specified instant
-    /// has occurred.
+    /// has occured.
+    @since(version = 0.2.0)
     subscribe-instant: func(
         when: instant,
     ) -> pollable;
 
     /// Create a `pollable` that will resolve after the specified duration has
     /// elapsed from the time this function is invoked.
+    @since(version = 0.2.0)
     subscribe-duration: func(
         when: duration,
     ) -> pollable;

--- a/wit/monotonic-clock.wit
+++ b/wit/monotonic-clock.wit
@@ -9,6 +9,7 @@ package wasi:clocks@0.2.0;
 /// successive reads of the clock will produce non-decreasing values.
 @since(version = 0.2.0)
 interface monotonic-clock {
+    @since(version = 0.2.0)
     use wasi:io/poll@0.2.0.{pollable};
 
     /// An instant in time, in nanoseconds. An instant is relative to an

--- a/wit/wall-clock.wit
+++ b/wit/wall-clock.wit
@@ -13,8 +13,10 @@ package wasi:clocks@0.2.0;
 /// monotonic, making it unsuitable for measuring elapsed time.
 ///
 /// It is intended for reporting the current date and time for humans.
+@since(version = 0.2.0)
 interface wall-clock {
     /// A time and date in seconds plus nanoseconds.
+    @since(version = 0.2.0)
     record datetime {
         seconds: u64,
         nanoseconds: u32,
@@ -33,10 +35,12 @@ interface wall-clock {
     ///
     /// [POSIX's Seconds Since the Epoch]: https://pubs.opengroup.org/onlinepubs/9699919799/xrat/V4_xbd_chap04.html#tag_21_04_16
     /// [Unix Time]: https://en.wikipedia.org/wiki/Unix_time
+    @since(version = 0.2.0)
     now: func() -> datetime;
 
     /// Query the resolution of the clock.
     ///
     /// The nanoseconds field of the output is always less than 1000000000.
+    @since(version = 0.2.0)
     resolution: func() -> datetime;
 }

--- a/wit/world.wit
+++ b/wit/world.wit
@@ -1,7 +1,10 @@
 package wasi:clocks@0.2.0;
 
+@since(version = 0.2.0)
 world imports {
+    @since(version = 0.2.0)
     import monotonic-clock;
+    @since(version = 0.2.0)
     import wall-clock;
     @unstable(feature = clocks-timezone)
     import timezone;


### PR DESCRIPTION
Depends on https://github.com/WebAssembly/component-model/pull/332 to be merged first. This documents the stability of all items using the `@since` gate notation, enabling WIT documents to be updated over time without major compatibility hazards.

For an overview of how this would apply to all existing WASI APIs, including the unstable `timezone` API, see https://github.com/WebAssembly/WASI/pull/604. Thanks!