### PR TITLE
chore: wit-abi-up-to-date v24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ jobs:
         ./wit-deps lock
         git add -N wit/deps
         git diff --exit-code
-    - uses: WebAssembly/wit-abi-up-to-date@v23
+    - uses: WebAssembly/wit-abi-up-to-date@v24
       with:
-        wit-bindgen: '0.37.0'
         all-features: 'true'


### PR DESCRIPTION
Fixes `Error: failed to find release for tag 'wasm-tools-1.215.0'`
