### PR TITLE
Add `get-*` prefix

### DIFF
--- a/wit-0.3.0-draft/monotonic-clock.wit
+++ b/wit-0.3.0-draft/monotonic-clock.wit
@@ -29,7 +29,7 @@ interface monotonic-clock {
     /// Query the resolution of the clock. Returns the duration of time
     /// corresponding to a clock tick.
     @since(version = 0.3.0)
-    resolution: func() -> duration;
+    get-resolution: func() -> duration;
 
     /// Wait until the specified instant has occurred.
     @since(version = 0.3.0)

--- a/wit-0.3.0-draft/wall-clock.wit
+++ b/wit-0.3.0-draft/wall-clock.wit
@@ -42,5 +42,5 @@ interface wall-clock {
     ///
     /// The nanoseconds field of the output is always less than 1000000000.
     @since(version = 0.3.0)
-    resolution: func() -> datetime;
+    get-resolution: func() -> datetime;
 }


### PR DESCRIPTION
As proposed in a [previous WASI meeting](https://docs.google.com/presentation/d/1on-QuMkOQ-2GCFcJG0DulxKIEDN4KrxveD--gFIzWyQ/edit?usp=sharing), this PR prefixes property-like methods with `get-`.
