### PR TITLE
Document that `monotonic-clock.now` doesn't wrap.

### DIFF
--- a/wit-0.3.0-draft/monotonic-clock.wit
+++ b/wit-0.3.0-draft/monotonic-clock.wit
@@ -23,6 +23,11 @@ interface monotonic-clock {
     ///
     /// The clock is monotonic, therefore calling this function repeatedly will
     /// produce a sequence of non-decreasing values.
+    ///
+    /// For completeness, this function traps if it's not possible to represent
+    /// the value of the clock in an `instant`. However, since `instant` can
+    /// represent over 584 years of time, this is not expected to occur in
+    /// practice.
     @since(version = 0.3.0-rc-2025-08-15)
     now: func() -> instant;
 

--- a/wit/monotonic-clock.wit
+++ b/wit/monotonic-clock.wit
@@ -26,6 +26,11 @@ interface monotonic-clock {
     ///
     /// The clock is monotonic, therefore calling this function repeatedly will
     /// produce a sequence of non-decreasing values.
+    ///
+    /// For completeness, this function traps if it's not possible to represent
+    /// the value of the clock in an `instant`. However, since `instant` can
+    /// represent over 584 years of time, this is not expected to occur in
+    /// practice.
     @since(version = 0.2.0)
     now: func() -> instant;
 


### PR DESCRIPTION
584 years ought to be enough for anyone.