### PR TITLE
p3: spec no-op `wait-for`/`wait-until`

### DIFF
--- a/wit-0.3.0-draft/monotonic-clock.wit
+++ b/wit-0.3.0-draft/monotonic-clock.wit
@@ -32,12 +32,16 @@ interface monotonic-clock {
     get-resolution: func() -> duration;
 
     /// Wait until the specified instant has occurred.
+    ///
+    /// If instant is in the past, this function will return immediately.
     @since(version = 0.3.0-rc-2025-08-15)
     wait-until: async func(
         when: instant,
     );
 
     /// Wait for the specified duration to elapse.
+    ///
+    /// If duration is equal to 0, this function will return immediately.
     @since(version = 0.3.0-rc-2025-08-15)
     wait-for: async func(
         how-long: duration,


### PR DESCRIPTION
Specify that `wait-for(0)` and `wait-until` with instants in the past must return immediately.

In Rust that means that these will always return `Poll::Ready(())`:
- `wait_for(0).poll(cx)` 
- `wait_until(now()).poll(cx)`