### PR TITLE
add new types.wit package to hold `duration`

### DIFF
--- a/wit-0.3.0-draft/monotonic-clock.wit
+++ b/wit-0.3.0-draft/monotonic-clock.wit
@@ -9,15 +9,13 @@ package wasi:clocks@0.3.0-rc-2025-08-15;
 /// successive reads of the clock will produce non-decreasing values.
 @since(version = 0.3.0-rc-2025-08-15)
 interface monotonic-clock {
+    use types.{duration};
+
     /// An instant in time, in nanoseconds. An instant is relative to an
     /// unspecified initial value, and can only be compared to instances from
     /// the same monotonic-clock.
     @since(version = 0.3.0-rc-2025-08-15)
     type instant = u64;
-
-    /// A duration of time, in nanoseconds.
-    @since(version = 0.3.0-rc-2025-08-15)
-    type duration = u64;
 
     /// Read the current value of the clock.
     ///

--- a/wit-0.3.0-draft/types.wit
+++ b/wit-0.3.0-draft/types.wit
@@ -1,0 +1,8 @@
+package wasi:clocks@0.3.0-rc-2025-08-15;
+/// This interface common types used throughout wasi:clocks.
+@since(version = 0.3.0-rc-2025-08-15)
+interface types {
+    /// A duration of time, in nanoseconds.
+    @since(version = 0.3.0-rc-2025-08-15)
+    type duration = u64;
+}


### PR DESCRIPTION
Per [suggestion](https://github.com/WebAssembly/wasi-clocks/pull/71#discussion_r2283444535) from @lann.